### PR TITLE
Update caniuse-lite to latest version

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2758,9 +2758,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001662",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001662.tgz",
-      "integrity": "sha512-sgMUVwLmGseH8ZIrm1d51UbrhqMCH3jvS7gF/M6byuHOnKyLOBL7W8yz5V02OHwgLGA36o/AFhWzzh4uc5aqTA==",
+      "version": "1.0.30001735",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001735.tgz",
+      "integrity": "sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==",
       "dev": true,
       "funding": [
         {
@@ -2775,7 +2775,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chokidar": {
       "version": "3.6.0",


### PR DESCRIPTION
## Purpose
The user was working on MongoDB connection setup and encountered various issues including outdated browser compatibility data. The system prompted to update the caniuse-lite package to resolve browserslist warnings and ensure up-to-date browser compatibility information.

## Code changes
- Updated `caniuse-lite` package from version `1.0.30001662` to `1.0.30001735`
- Added missing license field (`CC-BY-4.0`) to the package metadata
- Updated package integrity hash to match the new version

This update resolves the "caniuse-lite is outdated" warning and ensures the latest browser compatibility data is available for the project.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4c1442fe0ec74944a259b358a11b3598/pixel-realm)

👀 [Preview Link](https://4c1442fe0ec74944a259b358a11b3598-pixel-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4c1442fe0ec74944a259b358a11b3598</projectId>-->
<!--<branchName>pixel-realm</branchName>-->